### PR TITLE
Add method for extracting Box content

### DIFF
--- a/core/src/main/scala/lacasa/Box.scala
+++ b/core/src/main/scala/lacasa/Box.scala
@@ -58,6 +58,7 @@ sealed trait Safe[T]
 object Safe {
   implicit val nothingIsSafe: Safe[Nothing] = new Safe[Nothing] {}
   implicit val intIsSafe: Safe[Int] = new Safe[Int] {}
+  implicit val stringIsSafe: Safe[String] = new Safe[String] {}
   implicit def actorRefIsSafe[T]: Safe[ActorRef[T]] = new Safe[ActorRef[T]] {}
   implicit def tuple2IsSafe[T, S](implicit one: Safe[T], two: Safe[S]): Safe[(T, S)] = new Safe[(T, S)] {}
 }
@@ -79,6 +80,10 @@ sealed class Box[+T] private (private val instance: T) {
   def open(fun: Spore[T, Unit])(implicit access: CanAccess { type C = self.C }, noCapture: Safe[fun.Captured]): Box[T] = {
     fun(instance)
     self
+  }
+
+  def extract[S: Safe](fun: Spore[T, S])(implicit access: CanAccess { type C = self.C }, noCapture: Safe[fun.Captured]): S = {
+    fun(instance)
   }
 
   // swap field

--- a/core/src/test/scala/lacasa/test/example1.scala
+++ b/core/src/test/scala/lacasa/test/example1.scala
@@ -50,10 +50,8 @@ class ActorA extends Actor[Any] {
 class ActorB(p: Promise[String]) extends Actor[Message1] {
   override def receive(box: Box[Message1])
       (implicit acc: CanAccess { type C = box.C }) {
-    // mark as unsafe, since it captures Promise within `open`
-    box open { msg =>
-      p.success(msg.arr.mkString(","))
-    }
+    // Strings are Safe, and can therefore be extracted from the box.
+    p.success(box.extract(_.arr.mkString(",")))
   }
 }
 

--- a/samples/src/main/scala/samples/Unique.scala
+++ b/samples/src/main/scala/samples/Unique.scala
@@ -58,9 +58,7 @@ class ActorA(next: ActorRef[C]) extends Actor[Container] {
 class ActorB extends Actor[C] {
   def receive(msg: Box[C])(implicit access: CanAccess { type C = msg.C }): Unit = {
     println("ActorB received object with array")
-    msg.open(spore { x =>
-      println(x.arr.mkString(","))
-    })
+    println(msg.extract(_.arr.mkString(",")))
   }
 }
 


### PR DESCRIPTION
The return type from the Spore, and by extension `extract`, is constrained to be Safe, which
currently limits the usage quite substantially. It's a good starting
point, however.