### PR TITLE
Add `mkBoxFor`

### DIFF
--- a/core/src/main/scala/lacasa/Box.scala
+++ b/core/src/main/scala/lacasa/Box.scala
@@ -33,6 +33,14 @@ object Box {
     throw new NoReturnControl
   }
 
+  // TODO: ensure safety by checking shape of `instance` expression
+  def mkBoxFor[T](instance: => T)(fun: Packed[T] => Unit): Nothing = {
+    val theBox = new Box[T](instance)
+    val packed = theBox.pack()
+    fun(packed)
+    throw new NoReturnControl
+  }
+
   // marker method as escape hatch for ControlThrowable checker
   def uncheckedCatchControl: Unit = {}
 

--- a/core/src/test/scala/lacasa/test/BoxSpec.scala
+++ b/core/src/test/scala/lacasa/test/BoxSpec.scala
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2016 Philipp Haller
+ */
+package lacasa.test
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import lacasa.Box._
+
+
+class DoesNotHaveNoArgCtor(val num: Int) {
+  def incNum = new DoesNotHaveNoArgCtor(num + 1)
+}
+
+@RunWith(classOf[JUnit4])
+class BoxSpec {
+
+  @Test
+  def testMkBoxFor1(): Unit = {
+    try {
+      mkBoxFor(new DoesNotHaveNoArgCtor(0)) { packed =>
+        implicit val access = packed.access
+        val box: packed.box.type = packed.box
+        box.open { dnh =>
+          assert(dnh.num == 0)
+        }
+      }
+    } catch {
+      case t: Throwable =>
+        /* do nothing */
+    }
+  }
+
+  @Test
+  def testMkBoxFor2(): Unit = {
+    try {
+      val init = new DoesNotHaveNoArgCtor(0)
+      mkBoxFor(init.incNum) { packed =>
+        implicit val access = packed.access
+        val box: packed.box.type = packed.box
+        box.open { dnh =>
+          assert(dnh.num == 1)
+        }
+      }
+    } catch {
+      case t: Throwable =>
+        /* do nothing */
+    }
+  }
+
+}


### PR DESCRIPTION
The `mkBoxFor` method enables creating boxes also for new
instances of classes without a no-arg constructor.

Another pattern that needs to be supported is creating a box
for a new immutable instance created via method call (see test).

This commit does not add any compiler support. Compiler support
is required for checking that instance creation is safe.